### PR TITLE
Change default port from 3001 to 3000

### DIFF
--- a/server.js
+++ b/server.js
@@ -4,7 +4,7 @@ const multer = require('multer');
 const path = require('path');
 
 const app = express();
-const port = process.env.PORT || 3001;
+const port = process.env.PORT || 3000;
 
 // Middleware
 app.use(cors({


### PR DESCRIPTION
## Changes Made

Updated the default port configuration in `server.js`:

- Changed fallback port from `3001` to `3000` when `PORT` environment variable is not set
- Modified line 7: `const port = process.env.PORT || 3001;` → `const port = process.env.PORT || 3000;`

## Files Modified

- `server.js` - Updated default port valueTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/39750becec9b4fbf82ad4d464433f2db/pixel-forge)

👀 [Preview Link](https://39750becec9b4fbf82ad4d464433f2db-pixel-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>39750becec9b4fbf82ad4d464433f2db</projectId>-->
<!--<branchName>pixel-forge</branchName>-->