### PR TITLE
Add Vite Supabase environment variables to Netlify config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,8 @@
 
 [build.environment]
   NODE_VERSION = "18"
+  VITE_SUPABASE_URL = "https://txlraubydvzeeqcdvory.supabase.co"
+  VITE_SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InR4bHJhdWJ5ZHZ6ZWVxY2R2b3J5Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTg5MjYxNzEsImV4cCI6MjA3NDUwMjE3MX0.Hp51ErnZHO4MqAfmJHgH8Ad74kMjIgsA-VgyB9uQiwM"
 
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
## Purpose

Configure Supabase environment variables with proper Vite prefixes for Netlify deployment. The user needed to properly set up Supabase configuration that works with Vite's environment variable system, ensuring authentication flows and email events are properly handled.

## Code changes

- Added `VITE_SUPABASE_URL` environment variable to `netlify.toml` with the Supabase project URL
- Added `VITE_SUPABASE_ANON_KEY` environment variable to `netlify.toml` with the anonymous access key
- Both variables use the `VITE_` prefix required for Vite to expose them to the client-side applicationTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 12`

🔗 [Edit in Builder.io](https://builder.io/app/projects/7658c0c0c76645bfbb1e10598e5c16e2/curry-oasis)

👀 [Preview Link](https://7658c0c0c76645bfbb1e10598e5c16e2-curry-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7658c0c0c76645bfbb1e10598e5c16e2</projectId>-->
<!--<branchName>curry-oasis</branchName>-->