### PR TITLE
fix(auth): Use 'email_otp' for Supabase OTP verification

### DIFF
--- a/lib/supabaseClient.js
+++ b/lib/supabaseClient.js
@@ -28,7 +28,7 @@ export async function sendEmailOtp(email) {
 
 export async function verifyEmailOtp(email, token) {
   const client = getSupabase();
-  const { data, error } = await client.auth.verifyOtp({ email, token, type: 'email' });
+  const { data, error } = await client.auth.verifyOtp({ email, token, type: 'email_otp' });
   if (error) throw error;
   return data;
 }


### PR DESCRIPTION
The email OTP verification was failing for new user sign-ups because the `verifyOtp` function was called with `type: 'email'`. This type is intended for verifying passwordless sign-in, not for confirming a new user's email address.

This change updates the `type` parameter to `'email_otp'`, which is the correct type for handling both sign-in and sign-up email OTPs. This ensures that the verification flow works correctly in all scenarios.