### PR TITLE
fix: Correct Supabase OTP verification type and add config note

### DIFF
--- a/lib/supabaseClient.js
+++ b/lib/supabaseClient.js
@@ -16,6 +16,8 @@ export function getSupabase() {
   return supabase;
 }
 
+// Important: For emailRedirectTo to work in production, you must add your site's
+// URL to the "Redirect URLs" allow-list in your Supabase project's auth settings.
 export async function sendEmailOtp(email) {
   const client = getSupabase();
   const { data, error } = await client.auth.signInWithOtp({
@@ -28,7 +30,7 @@ export async function sendEmailOtp(email) {
 
 export async function verifyEmailOtp(email, token) {
   const client = getSupabase();
-  const { data, error } = await client.auth.verifyOtp({ email, token, type: 'email_otp' });
+  const { data, error } = await client.auth.verifyOtp({ email, token, type: 'email' });
   if (error) throw error;
   return data;
 }


### PR DESCRIPTION
This commit addresses two issues related to the email OTP functionality:

1.  The `verifyEmailOtp` function in `lib/supabaseClient.js` was using an incorrect `type` parameter ('email_otp'). This has been corrected to 'email' to align with the Supabase documentation and ensure OTPs can be verified successfully.

2.  A comment has been added to `lib/supabaseClient.js` to remind the user to add their site's URL to the Supabase project's redirect allow-list. This is a necessary step for the `emailRedirectTo` option to work correctly in a production environment.