### PR TITLE
fix(supabase): Make sendEmailOtp isomorphic

### DIFF
--- a/lib/supabaseClient.js
+++ b/lib/supabaseClient.js
@@ -18,11 +18,19 @@ export function getSupabase() {
 
 // Important: For emailRedirectTo to work in production, you must add your site's
 // URL to the "Redirect URLs" allow-list in your Supabase project's auth settings.
-export async function sendEmailOtp(email) {
+export async function sendEmailOtp(email, redirectTo = null) {
   const client = getSupabase();
+  const options = {
+    shouldCreateUser: true,
+  };
+
+  if (redirectTo) {
+    options.emailRedirectTo = redirectTo;
+  }
+
   const { data, error } = await client.auth.signInWithOtp({
     email,
-    options: { shouldCreateUser: true, emailRedirectTo: window.location.origin }
+    options,
   });
   if (error) throw error;
   return data;

--- a/script.js
+++ b/script.js
@@ -819,7 +819,7 @@ if (typeof document !== 'undefined') {
 
       try {
         const { sendEmailOtp } = await import('./lib/supabaseClient.js');
-        await sendEmailOtp(email);
+        await sendEmailOtp(email, window.location.origin);
 
         emailVerificationState.otpSent = true;
         showToast('Verification code sent to your email!', 'success');

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -1,0 +1,31 @@
+// test/test.mjs
+import { sendEmailOtp } from '../lib/supabaseClient.js';
+
+async function runTest() {
+  console.log("Running test to ensure server-side compatibility...");
+  try {
+    // This call is expected to fail because Supabase env vars are not configured
+    // in this test environment.
+    // However, the critical point is that it should NOT fail with a
+    // "ReferenceError: window is not defined".
+    await sendEmailOtp('test@example.com');
+
+    // We don't realistically expect to get here in a simple test runner,
+    // but if it runs without error, it means no reference to 'window' was hit.
+    console.log("TEST PASSED: sendEmailOtp executed without a 'window' reference error.");
+    process.exit(0);
+
+  } catch (error) {
+    if (error instanceof ReferenceError && error.message.includes("window is not defined")) {
+      console.error("TEST FAILED: The code still contains a reference to the `window` object, which is not available in a server-side environment.");
+      console.error(error);
+      process.exit(1); // Explicit failure
+    } else {
+      console.log("TEST PASSED: The code does not reference the `window` object.");
+      console.log(`(The function failed as expected, but for a different, acceptable reason: "${error.message}")`);
+      process.exit(0); // Explicit success
+    }
+  }
+}
+
+runTest();


### PR DESCRIPTION
The `sendEmailOtp` function in `lib/supabaseClient.js` directly accessed `window.location.origin`, which caused a `ReferenceError` when called in a non-browser environment.

This commit refactors the function to accept an optional `redirectTo` parameter. This makes the function isomorphic, allowing it to be used on both the client and server. The client-side call in `script.js` has been updated to pass `window.location.origin` to maintain existing functionality.

A new test has been added to verify that the function can be called in a Node.js environment without throwing a `ReferenceError`.